### PR TITLE
Move TpConfigSchema to core module.

### DIFF
--- a/modules/content-type/src/services/content-decompressor.service.spec.ts
+++ b/modules/content-type/src/services/content-decompressor.service.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -24,7 +25,7 @@ describe('content-decompressor.service.ts', function() {
 
         describe('.decompress()', function() {
 
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
                 .import(ContentTypeModule)
 
             const decompressor = platform.expose(ContentDecompressorService)!
@@ -83,7 +84,7 @@ describe('content-decompressor.service.ts', function() {
 
         describe('.load_decompressor()', function() {
 
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
                 .import(ContentDecompressorService)
                 .import({
                     provide: decompressor_token, useValue: ['err', (req: Readable) => req.pipe(new Transform({

--- a/modules/content-type/src/services/content-deserializer.service.spec.ts
+++ b/modules/content-type/src/services/content-deserializer.service.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -23,7 +24,7 @@ describe('content-deserializer.service.ts', function() {
 
         describe('.deserialize()', function() {
 
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
                 .import(ContentTypeModule)
 
             const deserializer = platform.expose(ContentDeserializerService)!
@@ -62,7 +63,7 @@ describe('content-deserializer.service.ts', function() {
 
         describe('.load_decompressor()', function() {
 
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
                 .import(ContentDeserializerService)
 
             const deserializer = platform.expose(ContentDeserializerService)!

--- a/modules/content-type/src/services/content-reader.service.spec.ts
+++ b/modules/content-type/src/services/content-reader.service.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -20,7 +21,7 @@ describe('content-reader.service.ts', function() {
 
         describe('.deserialize()', function() {
 
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
                 .import(ContentTypeModule)
 
             const reader = platform.expose(ContentReaderService)!

--- a/modules/core/src/builtin/tp-config-data.ts
+++ b/modules/core/src/builtin/tp-config-data.ts
@@ -5,7 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at source root.
  */
+import { ConfigData } from '@tarpit/config'
+import { TpConfigSchema } from '../types'
 
-// istanbul ignore file
-export { ConfigData } from './config-data'
-export { load_config } from './config-tools'
+export class TpConfigData extends ConfigData<TpConfigSchema> {
+
+}

--- a/modules/core/src/builtin/tp-inspector.spec.ts
+++ b/modules/core/src/builtin/tp-inspector.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
 import spies from 'chai-spies'
@@ -29,7 +30,7 @@ describe('tp-inspector.ts', function() {
 
     describe('TpInspector', function() {
 
-        const platform = new Platform({})
+        const platform = new Platform(load_config({}))
         const inspector = platform.expose(TpInspector)
 
         it('should show start and terminate thing as -1', function() {

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -29,6 +29,7 @@ export {
     TpWorker,
 } from './annotations'
 
+export { TpConfigData } from './builtin/tp-config-data'
 export { TpInspector } from './builtin/tp-inspector'
 export { TpLogger } from './builtin/tp-logger'
 export { TpLoader, TpLoaderType } from './builtin/tp-loader'

--- a/modules/core/src/platform.spec.ts
+++ b/modules/core/src/platform.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
 import { Debug, TpEntry, TpModule, TpRoot, TpService, TpUnit } from './annotations'
@@ -49,43 +50,43 @@ describe('platform.ts', function() {
 
     describe('Platform', function() {
         it('could create instance by new operator', function() {
-            expect(() => new Platform({})).to.not.throw()
+            expect(() => new Platform(load_config({}))).to.not.throw()
         })
     })
 
     describe('.import()', function() {
         it('should import ClassProviderDef to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import({ provide: Service1, useClass: Service1 })
             expect((platform as any).root_injector.get(Service1)?.create()).to.be.instanceof(Service1)
         })
 
         it('should import FactoryProviderDef to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import({ provide: Service1, useFactory: () => new Service1() })
             expect((platform as any).root_injector.get(Service1)?.create()).to.be.instanceof(Service1)
         })
 
         it('should import ValueProviderDef to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import({ provide: Service1, useValue: Service1 })
             expect((platform as any).root_injector.get(Service1)?.create()).to.equal(Service1)
         })
 
         it('should import TpService to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import(Service1)
             expect((platform as any).root_injector.get(Service1)?.create()).to.be.instanceof(Service1)
         })
 
         it('should import TpModule to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import(Module1)
             expect((platform as any).root_injector.get(Module1)?.create()).to.be.instanceof(Module1)
         })
 
         it('should import TpRoot to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import(Root1)
             expect((platform as any).root_injector.get(Root1)?.create()).to.be.instanceof(Root1)
         })
@@ -93,7 +94,7 @@ describe('platform.ts', function() {
 
     describe('.bootstrap()', function() {
         it('should bootstrap TpRoot to Platform', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.bootstrap(Root1)
             const meta = get_class_decorator(Root1)?.find(d => d instanceof TpEntry)
 
@@ -103,20 +104,20 @@ describe('platform.ts', function() {
         })
 
         it('should throw error if provided is not "TpEntry"', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             expect(() => platform.bootstrap(Noop)).to.throw('Noop is not a "TpEntry"')
         })
     })
 
     describe('.expose()', function() {
         it('should expose things from root injector', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             const inspector = platform.expose(TpInspector)
             expect(inspector).to.be.instanceof(TpInspector)
         })
 
         it('should expose undefined from provided not exists', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             const inspector = platform.expose(Noop)
             expect(inspector).to.be.undefined
         })
@@ -180,7 +181,7 @@ describe('platform.ts', function() {
         }
 
         it('should call all hooks', async function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import(SomeModule)
             platform.bootstrap(SomeRoot)
             const inspector = platform.expose(TpInspector)
@@ -197,7 +198,7 @@ describe('platform.ts', function() {
         })
 
         it('should catch and ignore error in hooks', function() {
-            const platform = new Platform({})
+            const platform = new Platform(load_config({}))
             platform.import(SomeModule)
         })
     })

--- a/modules/core/src/platform.ts
+++ b/modules/core/src/platform.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData, load_config, TpConfigSchema, } from '@tarpit/config'
+import { ConfigData } from '@tarpit/config'
 import { TpEntry } from './annotations'
+import { TpConfigData } from './builtin/tp-config-data'
 import { TpInspector } from './builtin/tp-inspector'
 import { TpLoader } from './builtin/tp-loader'
 import { TpLogger } from './builtin/tp-logger'
@@ -15,7 +16,7 @@ import { ClassProvider, Injector, ValueProvider } from './di'
 import { get_class_decorator } from './tools/decorator'
 import { check_usage, def_to_provider, load_component } from './tools/load-component'
 import { stringify } from './tools/stringify'
-import { AbstractConstructor, Constructor, ProviderDef } from './types'
+import { AbstractConstructor, Constructor, ProviderDef, TpConfigSchema } from './types'
 
 export class Platform {
 
@@ -25,11 +26,8 @@ export class Platform {
     private started = false
     private terminated = false
 
-    constructor(file_path?: string)
-    constructor(data: TpConfigSchema)
-    constructor(data: () => TpConfigSchema)
-    constructor(data?: string | TpConfigSchema | (() => TpConfigSchema)) {
-        ValueProvider.create(this.root_injector, { provide: ConfigData, useValue: load_config(data) })
+    constructor(data: ConfigData<TpConfigSchema>) {
+        ValueProvider.create(this.root_injector, { provide: TpConfigData, useValue: data })
         ValueProvider.create(this.root_injector, { provide: Platform, useValue: this })
         ClassProvider.create(this.root_injector, { provide: TpLogger, useClass: TpLogger }).create()
         this.root_injector.on('start', this.on_start)

--- a/modules/core/src/types/base.ts
+++ b/modules/core/src/types/base.ts
@@ -10,3 +10,6 @@ export type PureJSON = null | boolean | number | string | { [prop: string]: Pure
 export type Constructor<T> = new(...args: any[]) => T
 export type AbstractConstructor<T> = abstract new(...args: any[]) => T
 export type KeyOfFilterType<T, U> = { [K in keyof T]: Exclude<T[K], undefined> extends U ? K : never }[keyof T]
+
+export interface TpConfigSchema {
+}

--- a/modules/core/src/types/index.ts
+++ b/modules/core/src/types/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-export { Constructor, AbstractConstructor, PureJSON, KeyOfFilterType } from './base'
+export { Constructor, AbstractConstructor, PureJSON, KeyOfFilterType, TpConfigSchema } from './base'
 export { ClassProviderDef, FactoryProviderDef, ValueProviderDef, ProviderTreeNode, ProviderDef, Provider, ParentDesc } from './provider'
 export { TpEvent, TpEventCollector, InjectorType, InjectorEventEmitter } from './injector'
 export { TpRootOptions, TpModuleOptions, ImportsAndProviders, TpServiceOptions } from './options'

--- a/modules/http/src/index.ts
+++ b/modules/http/src/index.ts
@@ -9,7 +9,7 @@
 import { ProxyConfig } from './__types__'
 import { ResponseCacheControl } from './tools/cache-control'
 
-declare module '@tarpit/config' {
+declare module '@tarpit/core' {
 
     export interface TpConfigSchema {
         http: {

--- a/modules/http/src/services/http-body-formatter.ts
+++ b/modules/http/src/services/http-body-formatter.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { TpService } from '@tarpit/core'
+import { TpConfigData, TpService } from '@tarpit/core'
 import { HttpResponseType } from '../__types__'
 import { HttpContext } from '../builtin'
 import { HTTP_STATUS } from '../tools/http-status'
@@ -18,7 +17,7 @@ export class HttpBodyFormatter {
     private expose = this.config_data.get('http.expose_error') ?? false
 
     constructor(
-        private config_data: ConfigData,
+        private config_data: TpConfigData,
     ) {
     }
 

--- a/modules/http/src/services/http-routers.ts
+++ b/modules/http/src/services/http-routers.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
 import { ContentReaderService, text_deserialize } from '@tarpit/content-type'
-import { get_providers, Injector, TpService } from '@tarpit/core'
+import { get_providers, Injector, TpConfigData, TpService } from '@tarpit/core'
 import { IncomingMessage, ServerResponse } from 'http'
 import { Duplex, Readable, Transform, TransformCallback } from 'stream'
 import { WebSocket } from 'ws'
@@ -67,7 +66,7 @@ export class HttpRouters {
     private readonly c_proxy = this.config_data.get('http.proxy')
 
     constructor(
-        private config_data: ConfigData,
+        private config_data: TpConfigData,
         private url_parser: HttpUrlParser,
         private reader: ContentReaderService,
     ) {

--- a/modules/http/src/services/http-server.spec.ts
+++ b/modules/http/src/services/http-server.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -21,7 +22,7 @@ describe('http-server.ts', function() {
     describe('HttpServer', function() {
 
         it('should start and terminate', async function() {
-            const platform = new Platform({ http: { port: 31254 } })
+            const platform = new Platform(load_config({ http: { port: 31254 } }))
                 .import(HttpServerModule)
             const http_server = platform.expose(HttpServer)!
             expect(http_server).to.have.property('starting').which.is.undefined
@@ -40,7 +41,7 @@ describe('http-server.ts', function() {
         })
 
         it('should do nothing if calling terminate before start', async function() {
-            const platform = new Platform({ http: { port: 31254 } })
+            const platform = new Platform(load_config({ http: { port: 31254 } }))
                 .import(HttpServerModule)
             const http_server = platform.expose(HttpServer)!
             const terminating = http_server.terminate()
@@ -50,7 +51,7 @@ describe('http-server.ts', function() {
         })
 
         it('should return same promise if calling start multi times', async function() {
-            const platform = new Platform({ http: { port: 31254 } })
+            const platform = new Platform(load_config({ http: { port: 31254 } }))
                 .import(HttpServerModule)
             const http_server = platform.expose(HttpServer)!
             const starting = http_server.start(
@@ -65,7 +66,7 @@ describe('http-server.ts', function() {
         })
 
         it('should return same promise if calling terminate multi times', async function() {
-            const platform = new Platform({ http: { port: 31254 } })
+            const platform = new Platform(load_config({ http: { port: 31254 } }))
                 .import(HttpServerModule)
             const http_server = platform.expose(HttpServer)!
             await http_server.start(

--- a/modules/http/src/services/http-server.ts
+++ b/modules/http/src/services/http-server.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { Injector, TpService } from '@tarpit/core'
+import { Injector, TpConfigData, TpService } from '@tarpit/core'
 import http, { IncomingMessage, Server, ServerResponse } from 'http'
 import { Socket } from 'net'
 import { Duplex } from 'stream'
@@ -28,7 +27,7 @@ export class HttpServer {
 
     constructor(
         private injector: Injector,
-        private config_data: ConfigData
+        private config_data: TpConfigData
     ) {
     }
 

--- a/modules/http/src/services/http-static.ts
+++ b/modules/http/src/services/http-static.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { OnTerminate, TpService } from '@tarpit/core'
+import { TpConfigData, TpService } from '@tarpit/core'
 import fs, { ReadStream } from 'fs'
 import mime_types from 'mime-types'
 import { TpRequest, TpResponse } from '../builtin'
-import { finish, throw_forbidden, throw_not_found, throw_not_modified, throw_precondition_failed, TpHttpFinish } from '../errors'
+import { throw_forbidden, throw_not_found, throw_not_modified, throw_precondition_failed, TpHttpFinish } from '../errors'
 import { ResponseCacheControl } from '../tools/cache-control'
 import { FileWatcher, SearchedFile } from '../tools/file-watcher'
 
@@ -97,7 +96,7 @@ export class HttpStatic {
     private readonly file_watcher: FileWatcher
 
     constructor(
-        private config: ConfigData,
+        private config: TpConfigData,
     ) {
         const index = this.config.get('http.static.index') ?? ['index.html']
         const extensions = this.config.get('http.static.extensions') ?? ['.html']

--- a/modules/http/src/services/http-url-parser.spec.ts
+++ b/modules/http/src/services/http-url-parser.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
 import { get_first, HttpUrlParser } from './http-url-parser'
@@ -30,10 +31,10 @@ describe('http-url-parser.ts', function() {
 
         describe('.parse()', function() {
 
-            const proxy_platform = new Platform({ http: { port: 3000, proxy: { enable: true } } }).import(HttpUrlParser)
+            const proxy_platform = new Platform(load_config<TpConfigSchema>({ http: { port: 3000, proxy: { enable: true } } })).import(HttpUrlParser)
             const proxy_parser = proxy_platform.expose(HttpUrlParser)!
 
-            const no_proxy_platform = new Platform({ http: { port: 3000, proxy: { enable: false } } }).import(HttpUrlParser)
+            const no_proxy_platform = new Platform(load_config<TpConfigSchema>({ http: { port: 3000, proxy: { enable: false } } })).import(HttpUrlParser)
             const no_proxy_parser = no_proxy_platform.expose(HttpUrlParser)!
 
             it('should parse full url', function() {

--- a/modules/http/src/services/http-url-parser.ts
+++ b/modules/http/src/services/http-url-parser.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { TpService } from '@tarpit/core'
+import { TpConfigData, TpService } from '@tarpit/core'
 import url, { UrlWithParsedQuery } from 'url'
 
 export type RequestInfo = {
@@ -29,7 +28,7 @@ export class HttpUrlParser {
     private proxy_config = this.config_data.get('http.proxy')
 
     constructor(
-        private config_data: ConfigData,
+        private config_data: TpConfigData,
     ) {
     }
 

--- a/modules/http/test/authenticate.spec.ts
+++ b/modules/http/test/authenticate.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import { Jtl } from '@tarpit/judge'
 import axios from 'axios'
 import chai, { expect } from 'chai'
@@ -52,7 +53,7 @@ class TempRouter {
 
 describe('authenticate case', function() {
 
-    const platform = new Platform({ http: { port: 31254, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, expose_error: true } }))
         .bootstrap(TempRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/context.spec.ts
+++ b/modules/http/test/context.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpService } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpService } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -86,7 +87,7 @@ class TempRouter {
 
 describe('context case', function() {
 
-    const platform = new Platform({ http: { port: 31260, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31260, expose_error: true } }))
         .bootstrap(TempRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/cors.spec.ts
+++ b/modules/http/test/cors.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -25,13 +26,13 @@ class TempRouter {
 
 describe('context case', function() {
 
-    const platform = new Platform({
+    const platform = new Platform(load_config<TpConfigSchema>({
         http: {
             port: 31260,
             cors: { allow_headers: 'Authorization', allow_methods: 'GET,POST', allow_origin: '*', max_age: 3600 },
             expose_error: true,
         }
-    })
+    }))
         .bootstrap(TempRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/error.spec.ts
+++ b/modules/http/test/error.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -72,7 +73,7 @@ class NormalRouter {
 
 describe('errors case', function() {
 
-    const platform = new Platform({ http: { port: 31254, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, expose_error: true } }))
         .bootstrap(NormalRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/hooks.spec.ts
+++ b/modules/http/test/hooks.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpService } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpService } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -46,7 +47,7 @@ class TempRouter {
 
 describe('throw error in hooks case', function() {
 
-    const platform = new Platform({ http: { port: 31254, expose_error: true, body: { max_length: 10 } } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, expose_error: true, body: { max_length: 10 } } }))
         .import({ provide: HttpHooks, useClass: CustomHooks })
         .bootstrap(TempRouter)
 

--- a/modules/http/test/max-byte-length.spec.ts
+++ b/modules/http/test/max-byte-length.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -25,7 +26,7 @@ class TempRouter {
 
 describe('max-byte-length case', function() {
 
-    const platform = new Platform({ http: { port: 31254, expose_error: true, body: { max_length: 10 } } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, expose_error: true, body: { max_length: 10 } } }))
         .bootstrap(TempRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/normal.spec.ts
+++ b/modules/http/test/normal.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import { Jtl } from '@tarpit/judge'
 import axios from 'axios'
 import chai, { expect } from 'chai'
@@ -79,7 +80,7 @@ class NormalRouter {
 
 describe('normal case', function() {
 
-    const platform = new Platform({ http: { port: 31254, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, expose_error: true } }))
         .bootstrap(NormalRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/package.spec.ts
+++ b/modules/http/test/package.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
@@ -72,7 +73,7 @@ describe('HttpServerModule', function() {
 
     this.timeout(8000)
 
-    const platform = new Platform({ http: { port: 31254, server: { keepalive_timeout: 3000, terminate_timeout: 300 } } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, server: { keepalive_timeout: 3000, terminate_timeout: 300 } } }))
         .bootstrap(TestRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/request-body.spec.ts
+++ b/modules/http/test/request-body.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import { Jtl } from '@tarpit/judge'
 import axios from 'axios'
 import chai, { expect } from 'chai'
@@ -70,7 +71,7 @@ class RequestBodyRouter {
 
 describe('request body case', function() {
 
-    const platform = new Platform({ http: { port: 31260, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31260, expose_error: true } }))
         .bootstrap(RequestBodyRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/response-cache.spec.ts
+++ b/modules/http/test/response-cache.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpService } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpService } from '@tarpit/core'
 import { Jtl } from '@tarpit/judge'
 import axios from 'axios'
 import chai, { expect } from 'chai'
@@ -47,7 +48,7 @@ class TempRouter {
 
 describe('response cache case', function() {
 
-    const platform = new Platform({ http: { port: 31260, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31260, expose_error: true } }))
         .import(SomeMongo)
         .bootstrap(TempRouter)
 

--- a/modules/http/test/service-replace.spec.ts
+++ b/modules/http/test/service-replace.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpService } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpService } from '@tarpit/core'
 import axios from 'axios'
 import chai from 'chai'
 import cap from 'chai-as-promised'
@@ -52,7 +53,7 @@ class NormalRouter {
 
 describe('service replace case', function() {
 
-    const platform = new Platform({ http: { port: 31254, expose_error: true } })
+    const platform = new Platform(load_config<TpConfigSchema>({ http: { port: 31254, expose_error: true } }))
         .bootstrap(NormalRouter)
 
     const inspector = platform.expose(TpInspector)!

--- a/modules/http/test/static.spec.ts
+++ b/modules/http/test/static.spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { Platform, TpInspector } from '@tarpit/core'
+import { ConfigData, load_config } from '@tarpit/config'
+import { Platform, TpConfigData, TpConfigSchema, TpInspector } from '@tarpit/core'
 import axios from 'axios'
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
-import fs, { ReadStream } from 'fs'
+import { ReadStream } from 'fs'
 import { Get, HttpServerModule, HttpStatic, Params, PathArgs, TpHttpFinish, TpRequest, TpResponse, TpRouter } from '../src'
 import { create_stream, is_fresh, is_precondition_failure } from '../src/services/http-static'
 import { CacheControl } from '../src/tools/cache-control'
@@ -65,7 +65,7 @@ class StaticRouter {
 
 describe('static case', function() {
 
-    const platform = new Platform({
+    const platform = new Platform(load_config<TpConfigSchema>({
         http: {
             port: 31254, expose_error: true,
             static: {
@@ -77,7 +77,7 @@ describe('static case', function() {
                 vary: '*'
             }
         }
-    }).bootstrap(StaticRouter)
+    })).bootstrap(StaticRouter)
 
     const inspector = platform.expose(TpInspector)!
     const r = axios.create({ baseURL: 'http://localhost:31254', proxy: false })
@@ -243,7 +243,7 @@ describe('static case', function() {
         })
 
         it('should throw error if specified root path is not a directory', function() {
-            expect(() => new HttpStatic(new ConfigData({ http: { port: 3939, static: { root: './test/assets/some.txt' } } }))).to.throw()
+            expect(() => new HttpStatic(new TpConfigData({ http: { port: 3939, static: { root: './test/assets/some.txt' } } }))).to.throw()
         })
     })
 

--- a/modules/mongodb/src/index.ts
+++ b/modules/mongodb/src/index.ts
@@ -17,7 +17,7 @@ type TpOtherClientConfigMap = Exclude<TpMongoClientName, 'mongodb'> extends neve
     other_clients: Pick<TpMongoClientConfigMap, Exclude<TpMongoClientName, 'mongodb'>>
 }
 
-declare module '@tarpit/config' {
+declare module '@tarpit/core' {
 
     export interface TpConfigSchema {
         mongodb: TpMongoClientConfig & TpOtherClientConfigMap

--- a/modules/mongodb/src/services/mongo-hub.service.ts
+++ b/modules/mongodb/src/services/mongo-hub.service.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { TpService } from '@tarpit/core'
+import { TpConfigData, TpService } from '@tarpit/core'
 import { MongoClient, MongoClientOptions } from 'mongodb'
 
 import { TpMongo } from '../annotations/tp-mongo'
@@ -25,7 +24,7 @@ export class MongoHubService {
     private readonly client_map: MongoDBClientMap
 
     constructor(
-        private config: ConfigData
+        private config: TpConfigData
     ) {
         const config_map: TpMongoClientConfigMap = {
             mongodb: {

--- a/modules/mongodb/tests/normal.spec.ts
+++ b/modules/mongodb/tests/normal.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform, TpInspector, TpRoot } from '@tarpit/core'
 import { expect } from 'chai'
 import { ObjectId, WithId } from 'mongodb'
@@ -39,7 +40,7 @@ describe('normal case', function() {
     const tmp = console.log
     before(async function() {
         console.log = () => undefined
-        platform = new Platform({ mongodb: { url } })
+        platform = new Platform(load_config({ mongodb: { url } }))
             .import(MongodbModule)
             .import(TempRoot)
 

--- a/modules/mongodb/tests/unexpected.spec.ts
+++ b/modules/mongodb/tests/unexpected.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform, TpInspector } from '@tarpit/core'
 import { expect } from 'chai'
 import { GenericCollection, MongodbModule, TpMongo } from '../src'
@@ -30,7 +31,7 @@ describe('unexpected case', function() {
     const tmp = console.log
     before(async function() {
         console.log = () => undefined
-        platform = new Platform({ mongodb: { url } })
+        platform = new Platform(load_config({ mongodb: { url } }))
             .import(MongodbModule)
 
         inspector = platform.expose(TpInspector)!
@@ -47,13 +48,13 @@ describe('unexpected case', function() {
     })
 
     it('should throw an error if TpMongo is not inherit from GenericCollection', async function() {
-        const p = new Platform({ mongodb: { url } })
+        const p = new Platform(load_config({ mongodb: { url } }))
             .import(MongodbModule)
         expect(() => p.import(TestNoGenericMongo)).to.throw('A TpMongo class must inherit from GenericCollection directly.')
     })
 
     it('should throw an error if specified a client_name of nothing', async function() {
-        const p = new Platform({ mongodb: { url } })
+        const p = new Platform(load_config({ mongodb: { url } }))
             .import(MongodbModule)
         expect(() => p.import(TestNotExistClientMongo)).to.throw('Can not find specified MongoClient of name not_exists.')
     })

--- a/modules/rabbitmq/src/builtin/consumer.ts
+++ b/modules/rabbitmq/src/builtin/consumer.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { Injector } from '@tarpit/core'
+import { Injector, TpConfigData } from '@tarpit/core'
 import { Channel, ConsumeMessage } from 'amqplib'
 import { ConsumeOptions } from '../annotations/consume'
 import { RabbitSession } from './rabbit-session'
@@ -16,7 +15,7 @@ type ConsumeArguments = [queue: string, on_message: (msg: ConsumeMessage | null)
 
 export class Consumer extends RabbitSession<Channel> {
 
-    private config = this.injector.get(ConfigData)!.create()
+    private config = this.injector.get(TpConfigData)!.create()
     private prefetch = this.config.get('rabbitmq.prefetch')
     private consumers: ConsumeArguments[] = []
     private consumer_tags = new Set<string>()

--- a/modules/rabbitmq/src/index.ts
+++ b/modules/rabbitmq/src/index.ts
@@ -66,7 +66,7 @@ export interface AMQPConnect {
     vhost?: string
 }
 
-declare module '@tarpit/config' {
+declare module '@tarpit/core' {
 
     export interface TpConfigSchema {
         rabbitmq: {

--- a/modules/rabbitmq/src/services/rabbit-client.ts
+++ b/modules/rabbitmq/src/services/rabbit-client.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { Injector, TpService } from '@tarpit/core'
+import { Injector, TpConfigData, TpService } from '@tarpit/core'
 import { Connection } from 'amqplib'
 import { RabbitConnector } from './rabbit-connector'
 import { RabbitDefine, RabbitDefineToken } from './rabbit-define'
@@ -18,7 +17,7 @@ export class RabbitClient {
     private definition = new RabbitDefine()
 
     constructor(
-        private config_data: ConfigData,
+        private config_data: TpConfigData,
         private connector: RabbitConnector,
         private injector: Injector,
     ) {
@@ -51,12 +50,12 @@ export class RabbitClient {
         return
     }
 
-    private emit(event: any, data: any) {
-        this.injector.emit(event, data)
-    }
-
     async terminate() {
         return this.connector.close()
+    }
+
+    private emit(event: any, data: any) {
+        this.injector.emit(event, data)
     }
 
     private merge_definition() {

--- a/modules/rabbitmq/src/services/rabbit-connector.ts
+++ b/modules/rabbitmq/src/services/rabbit-connector.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
-import { ConfigData } from '@tarpit/config'
-import { Injector, TpService } from '@tarpit/core'
+import { Injector, TpConfigData, TpService } from '@tarpit/core'
 import { connect as connect_rabbitmq, Connection, Options } from 'amqplib'
 import net from 'net'
 import url from 'url'
@@ -54,7 +53,7 @@ export class RabbitConnector {
     private closed = false
 
     constructor(
-        private config: ConfigData,
+        private config: TpConfigData,
         private sessions: RabbitSessionCollector,
         private injector: Injector,
         private retry_strategy: RabbitRetryStrategy,

--- a/modules/rabbitmq/test/assert-definition.spec.ts
+++ b/modules/rabbitmq/test/assert-definition.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Injector, Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Injector, Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import { connect } from 'amqplib'
 import chai, { expect } from 'chai'
 import chai_spies from 'chai-spies'
@@ -54,7 +55,7 @@ describe('assert definition case', function() {
             .bind_queue('tarpit.exchange.b', 'tarpit.queue.b', 'bb')
             .bind_queue('tarpit.exchange.c', 'tarpit.queue.c', 'cc')
 
-        const platform = new Platform({ rabbitmq: { url } })
+        const platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url } }))
             .import({ provide: RabbitDefineToken, useValue: D, multi: true, root: true })
             .import(RabbitmqModule)
         const inspector = platform.expose(TpInspector)!
@@ -84,7 +85,7 @@ describe('assert definition case', function() {
 
     it('should throw error if definition conflicted', async function() {
         const D = new RabbitDefine().define_exchange('tarpit.exchange.a', 'direct', { durable: true })
-        const platform = new Platform({ rabbitmq: { url } })
+        const platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url } }))
         const inspector = platform.expose(TpInspector)!
         const injector = platform.expose(Injector)!
         injector.on('error', ({ type, error }) => {

--- a/modules/rabbitmq/test/connection.spec.ts
+++ b/modules/rabbitmq/test/connection.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Injector, Platform, TpInspector, TpService } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Injector, Platform, TpConfigSchema, TpInspector, TpService } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import chai_as_promised from 'chai-as-promised'
 import chai_spies from 'chai-spies'
@@ -49,7 +50,7 @@ describe('connection case', function() {
         let connector: RabbitConnector
 
         beforeEach(async function() {
-            platform = new Platform({ rabbitmq: { url: {}, timeout: 200 } })
+            platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url: {}, timeout: 200 } }))
 
             injector = platform.expose(Injector)!
             inspector = platform.expose(TpInspector)!
@@ -108,7 +109,7 @@ describe('connection case', function() {
 
         it('should mark connector closed if error occurred with code 320 or 200', async function() {
             const url = process.env.RABBITMQ_URL ?? ''
-            const platform = new Platform({ rabbitmq: { url, timeout: 200 } }).import(RabbitmqModule)
+            const platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url, timeout: 200 } })).import(RabbitmqModule)
             const injector = platform.expose(Injector)!
             injector.on('error', ({ type, error }) => console.log(type, error))
             const inspector = platform.expose(TpInspector)!

--- a/modules/rabbitmq/test/consume.spec.ts
+++ b/modules/rabbitmq/test/consume.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpService } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpService } from '@tarpit/core'
 import amqplib, { Connection } from 'amqplib'
 import chai, { expect } from 'chai'
 import chai_spies from 'chai-spies'
@@ -107,7 +108,7 @@ describe('consume case', function() {
     before(async function() {
         console.log = () => undefined
         connection = await amqplib.connect(url)
-        platform = new Platform({ rabbitmq: { url, prefetch: 10 } })
+        platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url, prefetch: 10 } }))
             .import(RabbitmqModule)
             .import(TempConsumer)
 

--- a/modules/rabbitmq/test/decorator-abused.spec.ts
+++ b/modules/rabbitmq/test/decorator-abused.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import amqplib, { Connection, GetMessage } from 'amqplib'
 import chai, { expect } from 'chai'
 import chai_as_promised from 'chai-as-promised'
@@ -47,7 +48,7 @@ describe('decorator abused case', function() {
     before(async function() {
         console.log = () => undefined
         connection = await amqplib.connect(url)
-        platform = new Platform({ rabbitmq: { url } })
+        platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url } }))
             .import({ provide: RabbitDefineToken, useValue: D, multi: true, root: true })
             .import(RabbitmqModule)
             .import(TempProducer)

--- a/modules/rabbitmq/test/normal.spec.ts
+++ b/modules/rabbitmq/test/normal.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpRoot } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpRoot } from '@tarpit/core'
 import amqplib, { Connection, GetMessage } from 'amqplib'
 import { expect } from 'chai'
 import crypto from 'crypto'
@@ -92,7 +93,7 @@ describe('normal case', function() {
     before(async function() {
         console.log = () => undefined
         connection = await amqplib.connect(url)
-        platform = new Platform({ rabbitmq: { url } })
+        platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url } }))
             .import(RabbitmqModule)
             .import(TempRoot)
 

--- a/modules/rabbitmq/test/produce-drain.spec.ts
+++ b/modules/rabbitmq/test/produce-drain.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Injector, Platform, TpInspector } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Injector, Platform, TpConfigSchema, TpInspector } from '@tarpit/core'
 import amqplib, { Connection } from 'amqplib'
 import { expect } from 'chai'
 import { ConfirmProducer, Enqueue, Producer, Publish, RabbitDefine, RabbitDefineToken, RabbitmqModule, TpProducer } from '../src'
@@ -55,7 +56,7 @@ describe('produce drain case', function() {
     before(async function() {
         console.log = () => undefined
         connection = await amqplib.connect(url)
-        platform = new Platform({ rabbitmq: { url } })
+        platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url } }))
             .import(RabbitmqModule)
             .import(TempProducer)
 

--- a/modules/rabbitmq/test/produce-error.spec.ts
+++ b/modules/rabbitmq/test/produce-error.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at source root.
  */
 
-import { Platform, TpInspector, TpRoot } from '@tarpit/core'
+import { load_config } from '@tarpit/config'
+import { Platform, TpConfigSchema, TpInspector, TpRoot } from '@tarpit/core'
 import amqplib, { Connection } from 'amqplib'
 import chai, { expect } from 'chai'
 import chai_as_promised from 'chai-as-promised'
@@ -48,7 +49,7 @@ describe('produce error case', function() {
     before(async function() {
         console.log = () => undefined
         connection = await amqplib.connect(url)
-        platform = new Platform({ rabbitmq: { url } })
+        platform = new Platform(load_config<TpConfigSchema>({ rabbitmq: { url } }))
             .import(RabbitmqModule)
             .import(TempRoot)
 

--- a/modules/schedule/src/services/schedule-inspector.spec.ts
+++ b/modules/schedule/src/services/schedule-inspector.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform, TpInspector } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import chai_spies from 'chai-spies'
@@ -40,7 +41,7 @@ describe('schedule-inspector.ts', function() {
         before(async function() {
             console.log = (..._args: any[]) => undefined
             chai.spy.on(Date, 'now', () => fake_time)
-            platform = new Platform({}).bootstrap(TempSchedule)
+            platform = new Platform(load_config({})).bootstrap(TempSchedule)
             inspector = platform.expose(TpInspector)!
             schedule_inspector = platform.expose(ScheduleInspector)!
             platform.start()

--- a/modules/schedule/test/error.spec.ts
+++ b/modules/schedule/test/error.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform, TpInspector } from '@tarpit/core'
 import chai from 'chai'
 import chai_spies from 'chai-spies'
@@ -68,7 +69,7 @@ describe('error case', function() {
     before(async function() {
         console.log = (..._args: any[]) => undefined
         chai.spy.on(Date, 'now', () => fake_time)
-        platform = new Platform({}).bootstrap(TempSchedule)
+        platform = new Platform(load_config({})).bootstrap(TempSchedule)
         inspector = platform.expose(TpInspector)!
         hooks = platform.expose(ScheduleHooks)!
         chai.spy.on(hooks, 'on_init')

--- a/modules/schedule/test/hooks.spec.ts
+++ b/modules/schedule/test/hooks.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform, TpInspector, TpService } from '@tarpit/core'
 import chai from 'chai'
 import chai_spies from 'chai-spies'
@@ -57,7 +58,7 @@ describe('hooks case', function() {
     before(async function() {
         console.log = (..._args: any[]) => undefined
         chai.spy.on(Date, 'now', () => fake_time)
-        platform = new Platform({}).bootstrap(TempSchedule)
+        platform = new Platform(load_config({})).bootstrap(TempSchedule)
         inspector = platform.expose(TpInspector)!
         hooks = platform.expose(ScheduleHooks)!
         chai.spy.on(hooks, 'on_init')

--- a/modules/schedule/test/normal.spec.ts
+++ b/modules/schedule/test/normal.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Optional, Platform, TpInspector, TpService } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import chai_spies from 'chai-spies'
@@ -44,7 +45,7 @@ describe('normal case', function() {
     before(async function() {
         console.log = (..._args: any[]) => undefined
         chai.spy.on(Date, 'now', () => fake_time)
-        platform = new Platform({}).bootstrap(TempSchedule)
+        platform = new Platform(load_config({})).bootstrap(TempSchedule)
         inspector = platform.expose(TpInspector)!
         schedule_inspector = platform.expose(ScheduleInspector)!
         platform.start()

--- a/modules/schedule/test/retry.spec.ts
+++ b/modules/schedule/test/retry.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at source root.
  */
 
+import { load_config } from '@tarpit/config'
 import { Platform, TpInspector } from '@tarpit/core'
 import chai, { expect } from 'chai'
 import chai_spies from 'chai-spies'
@@ -41,7 +42,7 @@ describe('retry case', function() {
     before(async function() {
         console.log = (..._args: any[]) => undefined
         chai.spy.on(Date, 'now', () => fake_time)
-        platform = new Platform({}).bootstrap(TempSchedule)
+        platform = new Platform(load_config({})).bootstrap(TempSchedule)
         inspector = platform.expose(TpInspector)!
         hooks = platform.expose(ScheduleHooks)!
         chai.spy.on(hooks, 'on_init')

--- a/package.json
+++ b/package.json
@@ -16,21 +16,7 @@
         "projects/*",
         "supports/*"
     ],
-    "dependencies": {
-        "@tarpit/barbeque": "^0.5.38",
-        "@tarpit/cli": "^0.5.38",
-        "@tarpit/config": "^0.5.38",
-        "@tarpit/content-type": "^0.5.38",
-        "@tarpit/core": "^0.5.38",
-        "@tarpit/cron": "^0.5.38",
-        "@tarpit/dora": "^0.5.38",
-        "@tarpit/error": "^0.5.38",
-        "@tarpit/http": "^0.5.38",
-        "@tarpit/judge": "^0.5.38",
-        "@tarpit/rabbitmq": "^0.5.38",
-        "@tarpit/rollup": "^0.5.0",
-        "@tarpit/schedule": "^0.5.38",
-        "@tarpit/transformer": "^0.5.38",
+    "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-typescript": "^11.0.0",

--- a/packages/config/src/config-data.ts
+++ b/packages/config/src/config-data.ts
@@ -9,24 +9,20 @@
 import { Reference } from '@tarpit/judge'
 import { Path, PathValue } from '@tarpit/type-tools'
 
-export interface TpConfigSchema {
-}
+export class ConfigData<T extends object> {
 
-export class ConfigData extends Reference<TpConfigSchema> {
+    private _data: Reference<T>
 
-    constructor(data: TpConfigSchema) {
-        super(data)
+    constructor(data: T) {
+        this._data = new Reference<T>(data)
     }
 
-    // @ts-ignore
-    get(): TpConfigSchema
-    // @ts-ignore
-    get<K extends Path<TpConfigSchema>>(path: K): PathValue<TpConfigSchema, K>
-    // @ts-ignore
-    get<K extends Path<TpConfigSchema>>(path?: K): PathValue<TpConfigSchema, K> | TpConfigSchema {
+    get(): T
+    get<K extends Path<T>>(path: K): PathValue<T, K>
+    get<K extends Path<T>>(path?: K): PathValue<T, K> | T {
         if (!path) {
-            return super.get()
+            return this._data.get()
         }
-        return super.get(path)!
+        return this._data.get(path)!
     }
 }

--- a/packages/config/src/config-tools.spec.ts
+++ b/packages/config/src/config-tools.spec.ts
@@ -9,7 +9,6 @@
 import chai, { expect } from 'chai'
 import cap from 'chai-as-promised'
 import fs from 'fs'
-import { TpConfigSchema } from './config-data'
 import { load_config } from './config-tools'
 
 chai.use(cap)
@@ -24,7 +23,7 @@ describe('config-tools.ts', function() {
                 b: 'string',
             }
             fs.writeFileSync('./tarpit.json', JSON.stringify(data))
-            const config_data = load_config()
+            const config_data = load_config<typeof data>()
             expect(config_data.get('a')).to.equal(123)
             expect(config_data.get('b')).to.equal('string')
             fs.rmSync('./tarpit.json')
@@ -40,7 +39,7 @@ describe('config-tools.ts', function() {
                 b: 'string'
             }
             fs.writeFileSync('./tmp-tarpit.spec.json', JSON.stringify(data))
-            const config_data = load_config('./tmp-tarpit.spec.json')
+            const config_data = load_config<typeof data>('./tmp-tarpit.spec.json')
             expect(config_data.get('a')).to.equal(123)
             expect(config_data.get('b')).to.equal('string')
             fs.rmSync('./tmp-tarpit.spec.json')
@@ -57,21 +56,21 @@ describe('config-tools.ts', function() {
         })
 
         it('should use data from given JSON.', function() {
-            const data: TpConfigSchema = {
+            const data = {
                 a: 123,
                 b: 'string'
-            } as any
+            }
             const config_data = load_config(data)
             expect(config_data.get('a')).to.equal(123)
             expect(config_data.get('b')).to.equal('string')
         })
 
         it('should use return value if given data is function.', function() {
-            const data: TpConfigSchema = {
+            const data = {
                 a: 123,
                 b: 'string'
-            } as any
-            const config_data = load_config(() => data)
+            }
+            const config_data = load_config<typeof data>(() => data)
             expect(config_data.get('a')).to.equal(123)
             expect(config_data.get('b')).to.equal('string')
         })

--- a/packages/config/src/config-tools.ts
+++ b/packages/config/src/config-tools.ts
@@ -8,22 +8,22 @@
 
 import fs from 'fs'
 import path from 'path'
-import { ConfigData, TpConfigSchema } from './config-data'
+import { ConfigData } from './config-data'
 
 function read_json(file: string) {
-    const res: TpConfigSchema = JSON.parse(fs.readFileSync(path.resolve(file)).toString('utf-8'))
+    const res: any = JSON.parse(fs.readFileSync(path.resolve(file)).toString('utf-8'))
     if (!res) {
         throw new Error('Specified configuration file is empty.')
     }
     return res
 }
 
-export function load_config(): ConfigData
-export function load_config(file_path: string | undefined): ConfigData
-export function load_config(data: TpConfigSchema): ConfigData
-export function load_config(data: () => TpConfigSchema): ConfigData
-export function load_config(data?: string | TpConfigSchema | (() => TpConfigSchema)): ConfigData
-export function load_config(data?: string | TpConfigSchema | (() => TpConfigSchema)): ConfigData {
+export function load_config<T extends object>(): ConfigData<T>
+export function load_config<T extends object>(file_path: string | undefined): ConfigData<T>
+export function load_config<T extends object>(data: T): ConfigData<T>
+export function load_config<T extends object>(data: () => T): ConfigData<T>
+export function load_config<T extends object>(data?: string | T | (() => T)): ConfigData<T>
+export function load_config<T extends object>(data?: string | T | (() => T)): ConfigData<T> {
     if (!data) {
         if (!fs.existsSync(path.resolve('tarpit.json'))) {
             throw new Error('No specified configuration file, and "tarpit.json" not exist.')
@@ -35,8 +35,8 @@ export function load_config(data?: string | TpConfigSchema | (() => TpConfigSche
         }
         return new ConfigData(read_json(data))
     } else if (typeof data === 'function') {
-        return new ConfigData(data())
+        return new ConfigData((data as Function)() as T)
     } else {
-        return new ConfigData(data)
+        return new ConfigData(data as T)
     }
 }


### PR DESCRIPTION
1. @tarpit/config module only focuses on loading config files.
2. Move the DI token of ConfigData into @tarpit/core.
3. fix type and unit tests.