### PR TITLE
fix: set useDefineForClassFields to false in tsup swc config

### DIFF
--- a/modules/content-type/CHANGELOG.md
+++ b/modules/content-type/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tarpit/content-type
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/config@2.0.1
+  - @tarpit/core@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/modules/content-type/package.json
+++ b/modules/content-type/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/content-type",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Content-type negotiation and body deserialization module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/modules/core/CHANGELOG.md
+++ b/modules/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tarpit/core
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/config@2.0.1
+  - @tarpit/type-tools@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/core",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Dependency injection framework and platform runtime for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/modules/http/CHANGELOG.md
+++ b/modules/http/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @tarpit/http
 
+## 2.1.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/config@2.0.1
+  - @tarpit/content-type@2.0.1
+  - @tarpit/core@2.0.1
+  - @tarpit/dora@2.0.1
+  - @tarpit/judge@2.0.1
+  - @tarpit/negotiator@2.0.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/modules/http/package.json
+++ b/modules/http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/http",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "HTTP server module for Tarpit with routing, WebSocket, and middleware support",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/modules/mongodb/CHANGELOG.md
+++ b/modules/mongodb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tarpit/mongodb
 
+## 2.0.2
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/config@2.0.1
+  - @tarpit/core@2.0.1
+
 ## 2.0.1
 
 ### Patch Changes

--- a/modules/mongodb/package.json
+++ b/modules/mongodb/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/mongodb",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "MongoDB integration module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/modules/rabbitmq/CHANGELOG.md
+++ b/modules/rabbitmq/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @tarpit/rabbitmq
 
+## 2.0.2
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/barbeque@2.0.1
+  - @tarpit/config@2.0.1
+  - @tarpit/content-type@2.0.1
+  - @tarpit/core@2.0.1
+  - @tarpit/judge@2.0.1
+
 ## 2.0.1
 
 ### Patch Changes

--- a/modules/rabbitmq/package.json
+++ b/modules/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/rabbitmq",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "RabbitMQ integration module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/modules/schedule/CHANGELOG.md
+++ b/modules/schedule/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @tarpit/schedule
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/config@2.0.1
+  - @tarpit/core@2.0.1
+  - @tarpit/cron@2.0.1
+  - @tarpit/dora@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/modules/schedule/package.json
+++ b/modules/schedule/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/schedule",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Cron-based task scheduling module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/barbeque/CHANGELOG.md
+++ b/packages/barbeque/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tarpit/barbeque
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/barbeque/package.json
+++ b/packages/barbeque/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/barbeque",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Optimized double-end queue based on the native array.",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tarpit/config
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/judge@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/config",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Type-safe configuration loader for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/cron/CHANGELOG.md
+++ b/packages/cron/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tarpit/cron
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/dora@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/cron",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Cron expression parser and scheduler",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/dora/CHANGELOG.md
+++ b/packages/dora/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tarpit/dora
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/dora/package.json
+++ b/packages/dora/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/dora",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Out of the box Date Object based on native Date.",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/judge/CHANGELOG.md
+++ b/packages/judge/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tarpit/judge
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
+- Updated dependencies
+  - @tarpit/type-tools@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/judge/package.json
+++ b/packages/judge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/judge",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Runtime type validation and assertion utilities",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/negotiator/CHANGELOG.md
+++ b/packages/negotiator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tarpit/negotiator
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/negotiator/package.json
+++ b/packages/negotiator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/negotiator",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "HTTP content negotiation utilities",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/transformer/CHANGELOG.md
+++ b/packages/transformer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tarpit/transformer
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/transformer",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "TypeScript AST transformer plugins for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/type-tools/CHANGELOG.md
+++ b/packages/type-tools/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tarpit/type-tools
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/type-tools/package.json
+++ b/packages/type-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/type-tools",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Some types that helped.",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/supports/cli/CHANGELOG.md
+++ b/supports/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tarpit/cli
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix class field initialization order in build output.
+
+  - Fix tsup swc plugin not respecting `useDefineForClassFields: false`, which caused native class fields to be preserved in ESM output and field initializers to run before constructor parameter assignments
+
 ## 2.0.0
 
 ### Major Changes

--- a/supports/cli/package.json
+++ b/supports/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/cli",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "> TODO: description",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    swc: {
+        jsc: {
+            transform: {
+                useDefineForClassFields: false,
+            },
+        },
+    },
+})


### PR DESCRIPTION
## Problem

tsup's swcPlugin (activated by `emitDecoratorMetadata: true`) intercepts all `.ts` files via an esbuild `onLoad` hook and transforms them with SWC instead of esbuild. The plugin hardcodes `jsc.target: "es2022"` and does not pass `useDefineForClassFields: false`, so SWC preserves native ES class field syntax.

This causes class field initializers to execute **before** constructor parameter assignments at runtime:

```js
var HttpServer = class {
  config_data;                                          // undefined
  port = this.config_data.get('http.port');              // TypeError!
  constructor(injector, config_data) {
    this.config_data = config_data;                     // too late
  }
}
```

## Fix

Add a root-level `tsup.config.ts` that sets `swc.jsc.transform.useDefineForClassFields: false`. tsup's config resolution (via joycon) walks up from each package directory, so all packages automatically pick up this config.

After the fix, the output correctly moves field initializers into the constructor body, after parameter assignments:

```js
var HttpServer = class {
  constructor(injector, config_data) {
    this.injector = injector;
    this.config_data = config_data;
    this.sockets = new Set();
    this.port = this.config_data.get('http.port');       // works
    this.keepalive_timeout = this.config_data.get('http.server.keepalive_timeout');
    this.terminate_timeout = this.config_data.get('http.server.terminate_timeout') ?? 4000;
  }
}
```

## Verification

- `pnpm -r build` passes, all packages use the root config
- `pnpm -r test` passes (1 pre-existing network-dependent failure in rabbitmq unrelated to this change)