### PR TITLE
feat(core): DAG-based lifecycle ordering for @OnStart and @OnTerminate

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,9 +3,29 @@
   "changelog": "@changesets/cli/changelog",
   "commit": true,
   "fixed": [],
-  "linked": [],
+  "linked": [
+    [
+      "@tarpit/core",
+      "@tarpit/config",
+      "@tarpit/content-type",
+      "@tarpit/http",
+      "@tarpit/mongodb",
+      "@tarpit/rabbitmq",
+      "@tarpit/schedule",
+      "@tarpit/barbeque",
+      "@tarpit/cron",
+      "@tarpit/dora",
+      "@tarpit/judge",
+      "@tarpit/negotiator",
+      "@tarpit/transformer",
+      "@tarpit/type-tools"
+    ]
+  ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/modules/content-type/package.json
+++ b/modules/content-type/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/content-type",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Content-type negotiation and body deserialization module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -51,8 +51,8 @@
         "@types/mime-types": "^2.1.1"
     },
     "peerDependencies": {
-        "@tarpit/config": "workspace:*",
-        "@tarpit/core": "workspace:*"
+        "@tarpit/config": "workspace:^",
+        "@tarpit/core": "workspace:^"
     },
     "sideEffects": true
 }

--- a/modules/core/CHANGELOG.md
+++ b/modules/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tarpit/core
 
+## 2.2.0
+
+### Minor Changes
+
+- DAG-based lifecycle ordering for `@OnStart` and `@OnTerminate` hooks.
+
+  - Add dependency-aware scheduling based on constructor injection graph
+  - Add `TpLoader.record()` to register component dependency relationships
+  - Add `TpLoader.register()` optional `deps` parameter for module-level dependencies
+  - Replace flat `Promise.allSettled` with eager per-node execution respecting DAG order
+  - Execute `@OnTerminate` hooks in reverse dependency order
+
 ## 2.0.1
 
 ### Patch Changes

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/core",
-    "version": "2.0.1",
+    "version": "2.2.0",
     "description": "Dependency injection framework and platform runtime for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -48,8 +48,8 @@
         "@tarpit/cli": "workspace:*"
     },
     "peerDependencies": {
-        "@tarpit/config": "workspace:*",
-        "@tarpit/type-tools": "workspace:*"
+        "@tarpit/config": "workspace:^",
+        "@tarpit/type-tools": "workspace:^"
     },
     "sideEffects": true
 }

--- a/modules/core/src/builtin/tp-loader.spec.ts
+++ b/modules/core/src/builtin/tp-loader.spec.ts
@@ -71,5 +71,193 @@ describe('tp-loader.ts', () => {
             expect(() => loader.load({ token: Symbol.for('non-exists') })).toThrow('Can\'t find loader for component \"undefined\"')
             expect(() => loader.load({ token: Symbol.for('non-exists'), cls: Noop })).toThrow('Can\'t find loader for component \"Noop\"')
         })
+
+        it('should execute on_start in dependency order', async () => {
+            const order: string[] = []
+            class A {}
+            class B {}
+            class C {}
+
+            loader.record(A, [])
+            loader.on_start(A, async () => { order.push('A') })
+            loader.record(B, [A])
+            loader.on_start(B, async () => { order.push('B') })
+            loader.record(C, [B])
+            loader.on_start(C, async () => { order.push('C') })
+
+            await loader.start()
+            expect(order).toEqual(['A', 'B', 'C'])
+        })
+
+        it('should execute on_terminate in reverse dependency order', async () => {
+            const order: string[] = []
+            class A {}
+            class B {}
+            class C {}
+
+            loader.record(A, [])
+            loader.on_terminate(A, async () => { order.push('A') })
+            loader.record(B, [A])
+            loader.on_terminate(B, async () => { order.push('B') })
+            loader.record(C, [B])
+            loader.on_terminate(C, async () => { order.push('C') })
+
+            await loader.terminate()
+            expect(order).toEqual(['C', 'B', 'A'])
+        })
+
+        it('should execute independent nodes in parallel within same layer', async () => {
+            const order: string[] = []
+            class A {}
+            class B {}
+            class C {}
+
+            loader.record(A, [])
+            loader.on_start(A, async () => { order.push('A') })
+            loader.record(B, [])
+            loader.on_start(B, async () => { order.push('B') })
+            loader.record(C, [A, B])
+            loader.on_start(C, async () => { order.push('C') })
+
+            await loader.start()
+            expect(order.slice(0, 2).sort()).toEqual(['A', 'B'])
+            expect(order[2]).toEqual('C')
+        })
+
+        it('should handle diamond dependency', async () => {
+            const order: string[] = []
+            class A {}
+            class B {}
+            class C {}
+            class D {}
+
+            loader.record(A, [])
+            loader.on_start(A, async () => { order.push('A') })
+            loader.record(B, [A])
+            loader.on_start(B, async () => { order.push('B') })
+            loader.record(C, [A])
+            loader.on_start(C, async () => { order.push('C') })
+            loader.record(D, [B, C])
+            loader.on_start(D, async () => { order.push('D') })
+
+            await loader.start()
+            expect(order[0]).toEqual('A')
+            expect(order.slice(1, 3).sort()).toEqual(['B', 'C'])
+            expect(order[3]).toEqual('D')
+        })
+
+        it('should ignore deps on non-existent nodes', async () => {
+            const order: string[] = []
+            class A {}
+            class Unknown {}
+
+            loader.record(A, [Unknown])
+            loader.on_start(A, async () => { order.push('A') })
+
+            await loader.start()
+            expect(order).toEqual(['A'])
+        })
+
+        it('should start node eagerly when its deps complete', async () => {
+            const timestamps: Record<string, number> = {}
+            class A {}
+            class B {}
+            class C {}
+
+            loader.record(A, [])
+            loader.on_start(A, async () => {
+                await new Promise(r => setTimeout(r, 50))
+                timestamps['A'] = Date.now()
+            })
+            loader.record(B, [])
+            loader.on_start(B, async () => {
+                await new Promise(r => setTimeout(r, 200))
+                timestamps['B'] = Date.now()
+            })
+            loader.record(C, [A])
+            loader.on_start(C, async () => {
+                timestamps['C_start'] = Date.now()
+            })
+
+            await loader.start()
+            expect(timestamps['C_start']).toBeLessThanOrEqual(timestamps['B'])
+        })
+
+        it('should handle register with deps', async () => {
+            const order: string[] = []
+            const token_a = Symbol.for('a')
+            const token_b = Symbol.for('b')
+
+            loader.register(token_a, {
+                on_start: async () => { order.push('A') },
+                on_terminate: async () => undefined,
+                on_load: () => undefined,
+            })
+            loader.register(token_b, {
+                on_start: async () => { order.push('B') },
+                on_terminate: async () => undefined,
+                on_load: () => undefined,
+            }, [token_a])
+
+            await loader.start()
+            expect(order).toEqual(['A', 'B'])
+        })
+
+        it('should handle mixed register and on_start nodes', async () => {
+            const order: string[] = []
+            const db_token = Symbol.for('db')
+            class CacheService {}
+
+            loader.register(db_token, {
+                on_start: async () => { order.push('db') },
+                on_terminate: async () => undefined,
+                on_load: () => undefined,
+            })
+            loader.record(CacheService, [db_token])
+            loader.on_start(CacheService, async () => {
+                order.push('cache')
+            })
+
+            await loader.start()
+            expect(order).toEqual(['db', 'cache'])
+        })
+
+        it('should propagate deps through intermediate nodes without hooks', async () => {
+            const order: string[] = []
+            class Database {}
+            class Repository {}
+            class CacheService {}
+
+            loader.record(Database, [])
+            loader.on_start(Database, async () => { order.push('db') })
+            loader.record(Repository, [Database])
+            loader.record(CacheService, [Repository])
+            loader.on_start(CacheService, async () => { order.push('cache') })
+
+            await loader.start()
+            expect(order).toEqual(['db', 'cache'])
+        })
+
+        it('should ignore null/undefined deps', async () => {
+            const order: string[] = []
+            class A {}
+
+            loader.record(A, [null, undefined])
+            loader.on_start(A, async () => { order.push('A') })
+
+            await loader.start()
+            expect(order).toEqual(['A'])
+        })
+
+        it('should ignore self-referencing deps', async () => {
+            const order: string[] = []
+            class A {}
+
+            loader.record(A, [A])
+            loader.on_start(A, async () => { order.push('A') })
+
+            await loader.start()
+            expect(order).toEqual(['A'])
+        })
     })
 })

--- a/modules/core/src/builtin/tp-loader.ts
+++ b/modules/core/src/builtin/tp-loader.ts
@@ -14,27 +14,42 @@ export type TpLoaderType = {
     on_load: (meta: any) => void
 }
 
+export interface LifecycleNode {
+    token: any
+    on_start?: () => Promise<void>
+    on_terminate?: () => Promise<void>
+    deps: Set<any>
+    dependents: Set<any>
+}
+
 @TpService()
 export class TpLoader {
 
-    private _on_starts: (() => Promise<void>)[] = []
-    private _on_terminates: (() => Promise<void>)[] = []
+    private _nodes: Map<any, LifecycleNode> = new Map()
     private _loaders: Map<symbol, TpLoaderType['on_load']> = new Map()
 
-    register(token: symbol, loader: TpLoaderType) {
+    register(token: symbol, loader: TpLoaderType, deps?: any[]) {
         if (!this._loaders.has(token)) {
             this._loaders.set(token, loader.on_load)
-            this._on_starts.push(loader.on_start)
-            this._on_terminates.push(loader.on_terminate)
+            const node = this._ensure_node(token)
+            node.on_start = loader.on_start
+            node.on_terminate = loader.on_terminate
+            if (deps) {
+                this._link_deps(node, deps)
+            }
         }
     }
 
-    on_start(init_method: () => Promise<any>) {
-        this._on_starts.push(init_method)
+    record(token: any, deps: any[]) {
+        this._link_deps(this._ensure_node(token), deps)
     }
 
-    on_terminate(quit_method: () => Promise<any>) {
-        this._on_terminates.push(quit_method)
+    on_start(token: any, init_method: () => Promise<void>) {
+        this._ensure_node(token).on_start = init_method
+    }
+
+    on_terminate(token: any, quit_method: () => Promise<void>) {
+        this._ensure_node(token).on_terminate = quit_method
     }
 
     load(meta: any & { token: symbol }) {
@@ -46,16 +61,67 @@ export class TpLoader {
     }
 
     async start(): Promise<void> {
-        await Promise.allSettled(this._on_starts.map((f) => f().catch(err => {
-            console.log(`Error occurred when starting: ${err.stack}`)
-        })))
-        return
+        await this._execute(
+            node => node.on_start?.().catch(err => {
+                console.log(`Error occurred when starting: ${err.stack}`)
+            }),
+            node => node.deps,
+        )
     }
 
     async terminate(): Promise<void> {
-        await Promise.allSettled(this._on_terminates.map((f) => f().catch(err => {
-            console.log(`Error occurred when terminating: ${err.stack}`)
-        })))
-        return
+        await this._execute(
+            node => node.on_terminate?.().catch(err => {
+                console.log(`Error occurred when terminating: ${err.stack}`)
+            }),
+            node => node.dependents,
+        )
+    }
+
+    private _ensure_node(token: any): LifecycleNode {
+        if (!this._nodes.has(token)) {
+            this._nodes.set(token, { token, deps: new Set(), dependents: new Set() })
+        }
+        return this._nodes.get(token)!
+    }
+
+    private _link_deps(node: LifecycleNode, deps: any[]) {
+        for (const dep of deps) {
+            if (dep == null || dep === node.token) {
+                continue
+            }
+            const dep_node = this._nodes.get(dep)
+            if (dep_node) {
+                node.deps.add(dep)
+                dep_node.dependents.add(node.token)
+            }
+        }
+    }
+
+    private async _execute(
+        run: (node: LifecycleNode) => Promise<any> | undefined,
+        get_wait_set: (node: LifecycleNode) => Set<any>,
+    ): Promise<void> {
+        const completions = new Map<any, { promise: Promise<void>, resolve: () => void }>()
+        for (const token of this._nodes.keys()) {
+            let resolve!: () => void
+            const promise = new Promise<void>(r => resolve = r)
+            completions.set(token, { promise, resolve })
+        }
+
+        const tasks: Promise<void>[] = []
+        for (const [token, node] of this._nodes) {
+            const wait_for = [...get_wait_set(node)]
+                .filter(dep => completions.has(dep))
+                .map(dep => completions.get(dep)!.promise)
+
+            const task = Promise.all(wait_for).then(async () => {
+                await run(node)
+                completions.get(token)!.resolve()
+            })
+            tasks.push(task)
+        }
+
+        await Promise.allSettled(tasks)
     }
 }

--- a/modules/core/src/tools/load-component.ts
+++ b/modules/core/src/tools/load-component.ts
@@ -10,7 +10,7 @@ import { OnStart, OnTerminate, TpAssembly, TpComponent, TpEntry, TpRoot, TpWorke
 import { TpLoader } from '../builtin/tp-loader'
 import { ClassProvider, FactoryProvider, Injector, ValueProvider } from '../di'
 import { ClassProviderDef, Constructor, FactoryProviderDef, Provider, ProviderDef, ProviderTreeNode, ValueProviderDef } from '../types'
-import { get_all_prop_decorator, get_class_decorator } from './decorator'
+import { get_all_prop_decorator, get_class_decorator, get_param_types } from './decorator'
 import { stringify } from './stringify'
 
 function isClassProviderDef<T extends object>(def: ProviderDef<T> | Constructor<any>): def is ClassProviderDef<T> {
@@ -88,14 +88,18 @@ export function load_component(meta: any, injector: Injector, auto_create?: bool
 
         const provider = meta.provider = ClassProvider.create(injector, { provide: meta.cls, useClass: meta.cls })
 
+        const constructor_deps = get_param_types(meta.cls)?.filter((t: any) => t != null) ?? []
+        const tp_loader = injector.get(TpLoader)?.create()
+        tp_loader?.record(meta.cls, constructor_deps)
+
         for (const [prop, decorators] of get_all_prop_decorator(meta.cls) ?? []) {
             if (decorators.find(d => d instanceof OnStart) && typeof Reflect.get(meta.cls.prototype, prop) === 'function') {
-                injector.get(TpLoader)!.create().on_start(async () => {
+                tp_loader?.on_start(meta.cls, async () => {
                     return provider.create()[prop]()
                 })
             }
             if (decorators.find(d => d instanceof OnTerminate) && typeof Reflect.get(meta.cls.prototype, prop) === 'function') {
-                injector.get(TpLoader)!.create().on_terminate(async () => {
+                tp_loader?.on_terminate(meta.cls, async () => {
                     return provider.create()[prop]()
                 })
             }

--- a/modules/http/package.json
+++ b/modules/http/package.json
@@ -61,12 +61,12 @@
         "iconv-lite": "^0.6.3"
     },
     "peerDependencies": {
-        "@tarpit/config": "workspace:*",
-        "@tarpit/content-type": "workspace:*",
-        "@tarpit/core": "workspace:*",
-        "@tarpit/dora": "workspace:*",
-        "@tarpit/judge": "workspace:*",
-        "@tarpit/negotiator": "workspace:*"
+        "@tarpit/config": "workspace:^",
+        "@tarpit/content-type": "workspace:^",
+        "@tarpit/core": "workspace:^",
+        "@tarpit/dora": "workspace:^",
+        "@tarpit/judge": "workspace:^",
+        "@tarpit/negotiator": "workspace:^"
     },
     "sideEffects": true
 }

--- a/modules/mongodb/package.json
+++ b/modules/mongodb/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/mongodb",
-    "version": "2.0.2",
+    "version": "2.1.1",
     "description": "MongoDB integration module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -47,8 +47,8 @@
         "@tarpit/cli": "workspace:*"
     },
     "peerDependencies": {
-        "@tarpit/core": "workspace:*",
-        "@tarpit/config": "workspace:*"
+        "@tarpit/core": "workspace:^",
+        "@tarpit/config": "workspace:^"
     },
     "sideEffects": true
 }

--- a/modules/rabbitmq/package.json
+++ b/modules/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/rabbitmq",
-    "version": "2.0.2",
+    "version": "2.1.1",
     "description": "RabbitMQ integration module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -49,11 +49,11 @@
         "@tarpit/cli": "workspace:*"
     },
     "peerDependencies": {
-        "@tarpit/barbeque": "workspace:*",
-        "@tarpit/config": "workspace:*",
-        "@tarpit/content-type": "workspace:*",
-        "@tarpit/core": "workspace:*",
-        "@tarpit/judge": "workspace:*"
+        "@tarpit/barbeque": "workspace:^",
+        "@tarpit/config": "workspace:^",
+        "@tarpit/content-type": "workspace:^",
+        "@tarpit/core": "workspace:^",
+        "@tarpit/judge": "workspace:^"
     },
     "sideEffects": true
 }

--- a/modules/schedule/package.json
+++ b/modules/schedule/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/schedule",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Cron-based task scheduling module for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -46,10 +46,10 @@
         "@tarpit/cli": "workspace:*"
     },
     "peerDependencies": {
-        "@tarpit/config": "workspace:*",
-        "@tarpit/core": "workspace:*",
-        "@tarpit/cron": "workspace:*",
-        "@tarpit/dora": "workspace:*"
+        "@tarpit/config": "workspace:^",
+        "@tarpit/core": "workspace:^",
+        "@tarpit/cron": "workspace:^",
+        "@tarpit/dora": "workspace:^"
     },
     "sideEffects": true
 }

--- a/packages/barbeque/package.json
+++ b/packages/barbeque/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/barbeque",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Optimized double-end queue based on the native array.",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/config",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Type-safe configuration loader for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -40,7 +40,7 @@
         "test": "vitest run --coverage"
     },
     "dependencies": {
-        "@tarpit/judge": "workspace:*"
+        "@tarpit/judge": "workspace:^"
     },
     "devDependencies": {
         "@tarpit/cli": "workspace:*",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/cron",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Cron expression parser and scheduler",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -40,7 +40,7 @@
         "test": "vitest run --coverage"
     },
     "dependencies": {
-        "@tarpit/dora": "workspace:*"
+        "@tarpit/dora": "workspace:^"
     },
     "devDependencies": {
         "@tarpit/cli": "workspace:*"

--- a/packages/dora/package.json
+++ b/packages/dora/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/dora",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Out of the box Date Object based on native Date.",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/judge/package.json
+++ b/packages/judge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/judge",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Runtime type validation and assertion utilities",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",
@@ -40,7 +40,7 @@
         "test": "vitest run --coverage"
     },
     "dependencies": {
-        "@tarpit/type-tools": "workspace:*"
+        "@tarpit/type-tools": "workspace:^"
     },
     "devDependencies": {
         "@tarpit/cli": "workspace:*"

--- a/packages/negotiator/package.json
+++ b/packages/negotiator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/negotiator",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "HTTP content negotiation utilities",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/transformer",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "TypeScript AST transformer plugins for Tarpit",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/packages/type-tools/package.json
+++ b/packages/type-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tarpit/type-tools",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "description": "Some types that helped.",
     "author": "Cao Jiahang <sieglive@gmail.com>",
     "homepage": "https://github.com/isatiso/node-tarpit#readme",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,10 +154,10 @@ importers:
   modules/content-type:
     dependencies:
       '@tarpit/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/config
       '@tarpit/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       iconv-lite:
         specifier: ^0.6.3
@@ -185,10 +185,10 @@ importers:
   modules/core:
     dependencies:
       '@tarpit/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/config
       '@tarpit/type-tools':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/type-tools
       reflect-metadata:
         specifier: ^0.2.2
@@ -207,22 +207,22 @@ importers:
   modules/http:
     dependencies:
       '@tarpit/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/config
       '@tarpit/content-type':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../content-type
       '@tarpit/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@tarpit/dora':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/dora
       '@tarpit/judge':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/judge
       '@tarpit/negotiator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/negotiator
       '@types/ws':
         specifier: ^8.5.5
@@ -280,10 +280,10 @@ importers:
   modules/mongodb:
     dependencies:
       '@tarpit/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/config
       '@tarpit/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       mongodb:
         specifier: ^7.1.1
@@ -299,19 +299,19 @@ importers:
   modules/rabbitmq:
     dependencies:
       '@tarpit/barbeque':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/barbeque
       '@tarpit/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/config
       '@tarpit/content-type':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../content-type
       '@tarpit/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@tarpit/judge':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/judge
       amqplib:
         specifier: ^1.0.3
@@ -333,16 +333,16 @@ importers:
   modules/schedule:
     dependencies:
       '@tarpit/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/config
       '@tarpit/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@tarpit/cron':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/cron
       '@tarpit/dora':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/dora
       tslib:
         specifier: ^2.8.1
@@ -361,7 +361,7 @@ importers:
   packages/config:
     dependencies:
       '@tarpit/judge':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../judge
     devDependencies:
       '@tarpit/cli':
@@ -374,7 +374,7 @@ importers:
   packages/cron:
     dependencies:
       '@tarpit/dora':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../dora
     devDependencies:
       '@tarpit/cli':
@@ -390,7 +390,7 @@ importers:
   packages/judge:
     dependencies:
       '@tarpit/type-tools':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../type-tools
     devDependencies:
       '@tarpit/cli':
@@ -446,7 +446,7 @@ importers:
         version: 11.1.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.11)(typescript@5.9.2)
+        version: 10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2)
     devDependencies:
       '@tarpit/type-tools':
         specifier: workspace:*
@@ -2010,56 +2010,67 @@ packages:
     resolution: {integrity: sha512-9fhTJyOb275w5RofPSl8lpr4jFowd+H4oQKJ9XTYzD1JWgxdZKE8bA6d4npuiMemkecQOcigX01FNZNCYnQBdA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.4':
     resolution: {integrity: sha512-+6kCIM5Zjvz2HwPl/udgVs07tPMIp1VU2Y0c72ezjOvSvEfAIWsUgpcSDvnC7g9NrjYR6X9bZT92mZZ90TfvXw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.4':
     resolution: {integrity: sha512-SWuXdnsayCZL4lXoo6jn0yyAj7TTjWE4NwDVt9s7cmu6poMhtiras5c8h6Ih6Y0Zk6Z+8t/mLumvpdSPTWub2Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.4':
     resolution: {integrity: sha512-vDknMDqtMhrrroa5kyX6tuC0aRZZlQ+ipDfbXd2YGz5HeV2t8HOl/FDAd2ynhs7Ki5VooWiiZcCtxiZ4IjqZwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.4':
     resolution: {integrity: sha512-mCBkjRZWhvjtl/x+Bd4fQkWZT8canStKDxGrHlBiTnZmJnWygGcvBylzLVCZXka4dco5ymkWhZlLwKCGFF4ivw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.4':
     resolution: {integrity: sha512-YMdz2phOTFF+Z66dQfGf0gmeDSi5DJzY5bpZyeg9CPBkV9QDzJ1yFRlmi/j7WWRf3hYIWrOaJj5jsfwgc8GTHQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.4':
     resolution: {integrity: sha512-r0WKLSfFAK8ucG024v2yiLSJMedoWvk8yWqfNICX28NHDGeu3F/wBf8KG6mclghx4FsLePxJr/9N8rIj1PtCnw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.4':
     resolution: {integrity: sha512-IaizpPP2UQU3MNyPH1u0Xxbm73D+4OupL0bjo4Hm0496e2wg3zuvoAIhubkD1NGy9fXILEExPQy87mweujEatA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.4':
     resolution: {integrity: sha512-aCM29orANR0a8wk896p6UEgIfupReupnmISz6SUwMIwTGaTI8MuKdE0OD2LvEg8ondDyZdMvnaN3bW4nFbATPA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.4':
     resolution: {integrity: sha512-0Xj1vZE3cbr/wda8d/m+UeuSL+TDpuozzdD4QaSzu/xSOMK0Su5RhIkF7KVHFQsobemUNHPLEcYllL7ZTCP/Cg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.4':
     resolution: {integrity: sha512-kM/orjpolfA5yxsx84kI6bnK47AAZuWxglGKcNmokw2yy9i5eHY5UAjcX45jemTJnfHAWo3/hOoRqEeeTdL5hw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.4':
     resolution: {integrity: sha512-cNLH4psMEsWKILW0isbpQA2OvjXLbKvnkcJFmqAptPQbtLrobiapBJVj6RoIvg6UXVp5w0wnIfd/Q56cNpF+Ew==}
@@ -2237,24 +2248,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.3':
     resolution: {integrity: sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.3':
     resolution: {integrity: sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.3':
     resolution: {integrity: sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.3':
     resolution: {integrity: sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==}
@@ -8750,7 +8765,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.28.3
       '@babel/traverse': 7.28.3
       '@docusaurus/logger': 3.8.0
@@ -12248,7 +12263,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -14633,19 +14648,19 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.1))(webpack@5.101.3(@swc/core@1.13.3)(esbuild@0.25.9)):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.1)'
       webpack: 5.101.3(@swc/core@1.13.3)(esbuild@0.25.9)
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.2
       react: 19.1.1
       react-router: 5.3.4(react@19.1.1)
 
   react-router-dom@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -14656,7 +14671,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -15582,6 +15597,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.13.3
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.17.2
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.3
 
   ts-patch@3.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

Replace flat parallel execution of `@OnStart` / `@OnTerminate` hooks with dependency-aware DAG scheduling based on constructor injection graph.

### Core changes
- `TpLoader` now maintains a DAG of lifecycle nodes with `deps` and `dependents` relationships
- New `TpLoader.record(token, deps)` method registers component dependency relationships for all components
- `TpLoader.register()` accepts optional `deps` parameter for module-level dependencies
- `@OnStart` hooks execute eagerly as soon as their direct dependencies complete (no layer-based waiting)
- `@OnTerminate` hooks execute in reverse dependency order
- Intermediate nodes without hooks still propagate dependency relationships

### Changeset & versioning
- Align all package versions to `2.1.1` baseline
- Configure `linked` versioning group for all `@tarpit/*` packages (major/minor aligned, patch independent)
- Change peerDependencies from `workspace:*` to `workspace:^` to prevent minor bumps cascading into major
- Add `onlyUpdatePeerDependentsWhenOutOfRange` to changeset config
- Release `@tarpit/core@2.2.0`

## Test plan
- [x] 15 new/updated tests for TpLoader covering dependency ordering, reverse termination, diamond deps, eager execution, intermediate node propagation, null/self-ref dep handling
- [x] 100% coverage on tp-loader.ts
- [x] All 141 core module tests pass
- [x] Full test suite passes (pre-existing failures only)